### PR TITLE
NOMERGE: Keybase fixes off alpha.23

### DIFF
--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -48,7 +48,9 @@
     if (!active) {
       [RNSScreenView walkThroughSubviewsAndBlurTextInputs:self];
     }
-    [_reactSuperview markChildUpdated];
+      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+          [self->_reactSuperview markChildUpdated];
+      });
   }
 }
 

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -48,9 +48,8 @@
     if (!active) {
       [RNSScreenView walkThroughSubviewsAndBlurTextInputs:self];
     }
-      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-          [self->_reactSuperview markChildUpdated];
-      });
+      
+      [self.reactSuperview markChildUpdated];
   }
 }
 
@@ -117,7 +116,7 @@
 
 - (void)notifyFinishTransitioning
 {
-  [_previousFirstResponder becomeFirstResponder];
+  //[_previousFirstResponder becomeFirstResponder];
   _previousFirstResponder = nil;
 }
 

--- a/ios/RNSScreen.m
+++ b/ios/RNSScreen.m
@@ -1,5 +1,6 @@
 #import "RNSScreen.h"
 #import "RNSScreenContainer.h"
+#import "RCTBaseTextInputView.h"
 
 @interface RNSScreen : UIViewController
 
@@ -23,10 +24,30 @@
   return self;
 }
 
++ (void)walkThroughSubviewsAndBlurTextInputs:(UIView *) view
+// This is a workaroud for an issue of preserving focus on mounting
+// and unmounting TextInput. In screen was set to inactive with focused
+// text input inside, textInput was still focused on reactivation of a screen.
+// It was invconsistent behavior with react-navigation without RNS.
+// What's more, then TextInput's focus couldn't be managed with
+// imperative API neither for bluring nor dismissing keyboard.
+{
+  if ([view isKindOfClass:[RCTBaseTextInputView class]]) {
+    [(RCTBaseTextInputView *)view reactBlur];
+  } else {
+    for (view in view.subviews) {
+      [RNSScreenView walkThroughSubviewsAndBlurTextInputs:view];
+    }
+  }
+}
+
 - (void)setActive:(BOOL)active
 {
   if (active != _active) {
     _active = active;
+    if (!active) {
+      [RNSScreenView walkThroughSubviewsAndBlurTextInputs:self];
+    }
     [_reactSuperview markChildUpdated];
   }
 }


### PR DESCRIPTION
- [x] https://github.com/kmagiera/react-native-screens/pull/77
- [x] fixes issue on chat thread. if you have a keyboard up and quickly wiggle the thread by swiping you can easily get a deadlock. This commit defers some deregistering which stops that from happening